### PR TITLE
[FEAT] 검색 기능 추가 구현

### DIFF
--- a/src/components/rootlayouts/Header.tsx
+++ b/src/components/rootlayouts/Header.tsx
@@ -45,6 +45,7 @@ export default function Header() {
   useEffect(() => {
     if (location.pathname !== "/search") {
       setPreviousPath(location.pathname);
+      setIsSearch(false);
     }
   }, [navigate, previousPath]);
 

--- a/src/components/rootlayouts/Searchbar.tsx
+++ b/src/components/rootlayouts/Searchbar.tsx
@@ -149,6 +149,9 @@ export default function Searchbar() {
                 </div>
                 {currentTab === "전체" && (
                   <div className="max-h-[calc(100vh-320px)] overflow-y-auto mt-[30px]">
+                    {searchResults.length === 0 && (
+                      <div>'{searchValue}'에 대한 검색 결과가 없습니다</div>
+                    )}
                     {searchResults.map((result) => (
                       <div
                         key={result.id}
@@ -179,6 +182,9 @@ export default function Searchbar() {
                 )}
                 {currentTab === "시리즈" && (
                   <div className="max-h-[calc(100vh-320px)] overflow-y-auto mt-[30px]">
+                    {searchTVResults.length === 0 && (
+                      <div>'{searchValue}'에 대한 검색 결과가 없습니다</div>
+                    )}
                     {searchTVResults.map((result) => (
                       <div
                         key={result.id}
@@ -207,6 +213,9 @@ export default function Searchbar() {
                 )}
                 {currentTab === "영화" && (
                   <div className="max-h-[calc(100vh-320px)] overflow-y-auto mt-[30px]">
+                    {searchMovieResults.length === 0 && (
+                      <div>'{searchValue}'에 대한 검색 결과가 없습니다</div>
+                    )}
                     {searchMovieResults.map((result) => (
                       <div
                         key={result.id}
@@ -238,6 +247,7 @@ export default function Searchbar() {
           </div>
         </div>
       </div>
+
       {/* tablet */}
       <div className="desktop:hidden mobile:hidden tablet:flex">
         <div className="w-[100%] h-[100%] py-[50px] px-[58px] flex flex-col justify-between items-center">
@@ -298,6 +308,9 @@ export default function Searchbar() {
                 </div>
                 {currentTab === "전체" && (
                   <div className="max-h-[calc(100vh-320px)] overflow-y-auto mt-[30px]">
+                    {searchResults.length === 0 && (
+                      <div>'{searchValue}'에 대한 검색 결과가 없습니다</div>
+                    )}
                     {searchResults.map((result) => (
                       <div
                         key={result.id}
@@ -328,6 +341,9 @@ export default function Searchbar() {
                 )}
                 {currentTab === "시리즈" && (
                   <div className="max-h-[calc(100vh-320px)] overflow-y-auto mt-[30px]">
+                    {searchTVResults.length === 0 && (
+                      <div>'{searchValue}'에 대한 검색 결과가 없습니다</div>
+                    )}
                     {searchTVResults.map((result) => (
                       <div
                         key={result.id}
@@ -356,6 +372,9 @@ export default function Searchbar() {
                 )}
                 {currentTab === "영화" && (
                   <div className="max-h-[calc(100vh-320px)] overflow-y-auto mt-[30px]">
+                    {searchMovieResults.length === 0 && (
+                      <div>'{searchValue}'에 대한 검색 결과가 없습니다</div>
+                    )}
                     {searchMovieResults.map((result) => (
                       <div
                         key={result.id}
@@ -387,6 +406,7 @@ export default function Searchbar() {
           </div>
         </div>
       </div>
+
       {/* mobile */}
       <div className="desktop:hidden tablet:hidden mobile:flex">
         <div className="w-full h-full py-[50px] px-[10px] flex flex-col justify-between items-center ">
@@ -447,6 +467,11 @@ export default function Searchbar() {
                 </div>
                 {currentTab === "전체" && (
                   <div className="max-h-[calc(100vh-320px)] overflow-y-auto mt-[30px]">
+                    {searchResults.length === 0 && (
+                      <div className="text-[16px]">
+                        '{searchValue}'에 대한 검색 결과가 없습니다
+                      </div>
+                    )}
                     {searchResults.map((result) => (
                       <div
                         key={result.id}
@@ -477,6 +502,11 @@ export default function Searchbar() {
                 )}
                 {currentTab === "시리즈" && (
                   <div className="max-h-[calc(100vh-320px)] overflow-y-auto mt-[30px]">
+                    {searchTVResults.length === 0 && (
+                      <div className="text-[16px]">
+                        '{searchValue}'에 대한 검색 결과가 없습니다
+                      </div>
+                    )}
                     {searchTVResults.map((result) => (
                       <div
                         key={result.id}
@@ -505,6 +535,11 @@ export default function Searchbar() {
                 )}
                 {currentTab === "영화" && (
                   <div className="max-h-[calc(100vh-320px)] overflow-y-auto mt-[30px]">
+                    {searchMovieResults.length === 0 && (
+                      <div className="text-[16px]">
+                        '{searchValue}'에 대한 검색 결과가 없습니다
+                      </div>
+                    )}
                     {searchMovieResults.map((result) => (
                       <div
                         key={result.id}

--- a/src/components/rootlayouts/Searchbar.tsx
+++ b/src/components/rootlayouts/Searchbar.tsx
@@ -55,7 +55,6 @@ export default function Searchbar() {
     setCurrentTab(tab);
   };
 
-  // 검색어 입력 전 & 검색어 지웠을 때 보여줄 트랜드 컨텐츠 패칭
   const fetchTrendingContents = async () => {
     try {
       const response: ContentsType = await commonAPI.getTrendingAll(1);

--- a/src/components/rootlayouts/Searchbar.tsx
+++ b/src/components/rootlayouts/Searchbar.tsx
@@ -3,6 +3,8 @@ import seachIcon from "../../assets/icon/searchIcon.svg";
 import { commonAPI } from "../../api/common";
 import { searchAPI } from "../../api/search";
 import useDebounce from "../../hooks/useDebounce";
+import { mediaTypeToPathName } from "../../constants/path";
+import { useNavigate } from "react-router-dom";
 
 interface ContentType {
   adult: boolean;
@@ -46,6 +48,7 @@ export default function Searchbar() {
   >([]);
   const debouncedValue = useDebounce(searchValue, 200);
   const [currentTab, setCurrentTab] = useState("전체");
+  const navigate = useNavigate();
 
   const handleSearchInput = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value);
@@ -53,6 +56,12 @@ export default function Searchbar() {
 
   const handleTabChange = (tab: string) => {
     setCurrentTab(tab);
+  };
+
+  const handleContentClick = (content: ContentType) => {
+    if (!content.media_type) return;
+    const path = mediaTypeToPathName[content.media_type as "movie" | "tv"];
+    if (path) navigate(`/${path}/${content.id}`);
   };
 
   const fetchTrendingContents = async () => {
@@ -104,7 +113,12 @@ export default function Searchbar() {
             {!searchValue ? <p>트렌드 컨텐츠</p> : ""}
             {!searchValue ? (
               trendingContents.map((content, index) => (
-                <div className="flex text-[16px]" key={content.id}>
+                <div
+                  className="flex text-[16px] cursor-pointer"
+                  key={content.id}
+                  onClick={() => {
+                    handleContentClick(content);
+                  }}>
                   <div className="w-[20px] text-main mr-[20px]">
                     {index + 1}
                   </div>
@@ -154,7 +168,10 @@ export default function Searchbar() {
                     {searchResults.map((result) => (
                       <div
                         key={result.id}
-                        className="flex items-center gap-[20px] mb-[30px]">
+                        className="flex items-center gap-[20px] mb-[30px] cursor-pointer"
+                        onClick={() => {
+                          handleContentClick(result);
+                        }}>
                         <div className="w-[109px] h-[144px]">
                           <img
                             src={`https://image.tmdb.org/t/p/w220_and_h330_face/${result.poster_path}`}
@@ -187,7 +204,10 @@ export default function Searchbar() {
                     {searchTVResults.map((result) => (
                       <div
                         key={result.id}
-                        className="flex items-center gap-[20px] mb-[30px]">
+                        className="flex items-center gap-[20px] mb-[30px] cursor-pointer"
+                        onClick={() => {
+                          handleContentClick(result);
+                        }}>
                         <div className="w-[109px] h-[144px]">
                           <img
                             src={`https://image.tmdb.org/t/p/w220_and_h330_face/${result.poster_path}`}
@@ -218,7 +238,10 @@ export default function Searchbar() {
                     {searchMovieResults.map((result) => (
                       <div
                         key={result.id}
-                        className="flex items-center gap-[20px] mb-[30px]">
+                        className="flex items-center gap-[20px] mb-[30px] cursor-pointer"
+                        onClick={() => {
+                          handleContentClick(result);
+                        }}>
                         <div className="w-[109px] h-[144px]">
                           <img
                             src={`https://image.tmdb.org/t/p/w220_and_h330_face/${result.poster_path}`}
@@ -263,7 +286,12 @@ export default function Searchbar() {
             {!searchValue ? <p>트렌드 컨텐츠</p> : ""}
             {!searchValue ? (
               trendingContents.map((content, index) => (
-                <div className="flex text-[16px]" key={content.id}>
+                <div
+                  className="flex text-[16px] cursor-pointer"
+                  key={content.id}
+                  onClick={() => {
+                    handleContentClick(content);
+                  }}>
                   <div className="w-[20px] text-main mr-[20px]">
                     {index + 1}
                   </div>
@@ -313,7 +341,10 @@ export default function Searchbar() {
                     {searchResults.map((result) => (
                       <div
                         key={result.id}
-                        className="flex items-center gap-[20px] mb-[30px]">
+                        className="flex items-center gap-[20px] mb-[30px] cursor-pointer"
+                        onClick={() => {
+                          handleContentClick(result);
+                        }}>
                         <div className="w-[109px] h-[144px]">
                           <img
                             src={`https://image.tmdb.org/t/p/w220_and_h330_face/${result.poster_path}`}
@@ -346,7 +377,10 @@ export default function Searchbar() {
                     {searchTVResults.map((result) => (
                       <div
                         key={result.id}
-                        className="flex items-center gap-[20px] mb-[30px]">
+                        className="flex items-center gap-[20px] mb-[30px] cursor-pointer"
+                        onClick={() => {
+                          handleContentClick(result);
+                        }}>
                         <div className="w-[109px] h-[144px]">
                           <img
                             src={`https://image.tmdb.org/t/p/w220_and_h330_face/${result.poster_path}`}
@@ -377,7 +411,10 @@ export default function Searchbar() {
                     {searchMovieResults.map((result) => (
                       <div
                         key={result.id}
-                        className="flex items-center gap-[20px] mb-[30px]">
+                        className="flex items-center gap-[20px] mb-[30px] cursor-pointer"
+                        onClick={() => {
+                          handleContentClick(result);
+                        }}>
                         <div className="w-[109px] h-[144px]">
                           <img
                             src={`https://image.tmdb.org/t/p/w220_and_h330_face/${result.poster_path}`}
@@ -422,7 +459,12 @@ export default function Searchbar() {
             {!searchValue ? <p>트렌드 컨텐츠</p> : ""}
             {!searchValue ? (
               trendingContents.map((content, index) => (
-                <div className="flex text-[14px]" key={content.id}>
+                <div
+                  className="flex text-[14px] cursor-pointer"
+                  key={content.id}
+                  onClick={() => {
+                    handleContentClick(content);
+                  }}>
                   <div className="w-[20px] text-main mr-[20px]">
                     {index + 1}
                   </div>
@@ -474,7 +516,10 @@ export default function Searchbar() {
                     {searchResults.map((result) => (
                       <div
                         key={result.id}
-                        className="flex items-center gap-[20px] mb-[30px]">
+                        className="flex items-center gap-[20px] mb-[30px] cursor-pointer"
+                        onClick={() => {
+                          handleContentClick(result);
+                        }}>
                         <div className="w-[70px] h-[94px]">
                           <img
                             src={`https://image.tmdb.org/t/p/w220_and_h330_face/${result.poster_path}`}
@@ -509,7 +554,10 @@ export default function Searchbar() {
                     {searchTVResults.map((result) => (
                       <div
                         key={result.id}
-                        className="flex items-center gap-[20px] mb-[30px]">
+                        className="flex items-center gap-[20px] mb-[30px] cursor-pointer"
+                        onClick={() => {
+                          handleContentClick(result);
+                        }}>
                         <div className="w-[70px] h-[94px]">
                           <img
                             src={`https://image.tmdb.org/t/p/w220_and_h330_face/${result.poster_path}`}
@@ -542,7 +590,10 @@ export default function Searchbar() {
                     {searchMovieResults.map((result) => (
                       <div
                         key={result.id}
-                        className="flex items-center gap-[20px] mb-[30px]">
+                        className="flex items-center gap-[20px] mb-[30px] cursor-pointer"
+                        onClick={() => {
+                          handleContentClick(result);
+                        }}>
                         <div className="min-w-[70px] h-[94px]">
                           <img
                             src={`https://image.tmdb.org/t/p/w220_and_h330_face/${result.poster_path}`}

--- a/src/components/rootlayouts/Searchbar.tsx
+++ b/src/components/rootlayouts/Searchbar.tsx
@@ -44,7 +44,7 @@ export default function Searchbar() {
   const [searchMovieResults, setSearchMovieResults] = useState<
     ContentType[] | []
   >([]);
-  const debouncedValue = useDebounce(searchValue, 500);
+  const debouncedValue = useDebounce(searchValue, 200);
   const [currentTab, setCurrentTab] = useState("전체");
 
   const handleSearchInput = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

#20 

## 📝작업 내용

- 검색 결과가 없을 때 출력할 컨텐츠 추가
- 검색 결과 입력 전 트랜드 컨텐츠 클릭 시 상세페이지로 이동 구현
- 검색 결과 클릭 시 해당 컨텐츠의 상세페이지로의 이동 구현
- 컨텐츠의 상세페이지로의 이동에 의해 라우팅 경로가 변경될 때 검색창 닫힘 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
