### PR TITLE
Fix 메인썸네일상세페이지 #43

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.1",
     "supabase": "^2.9.6",
-    "swiper": "^11.2.2",
+    "swiper": "^11.2.5",
     "tailwind-merge": "^2.5.5"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ export default function App() {
           />
 
           {/* 영화 상세페이지 */}
-          <Route path="/detailmovie" element={<DetailMovie />} />
+          <Route path="/detailmovie/:movieid" element={<DetailMovie />} />
           {/* 예고편 */}
           <Route path="/trailers" element={<Trailers />} />
         </Route>

--- a/src/api/movie.ts
+++ b/src/api/movie.ts
@@ -8,6 +8,7 @@ const getMovieTrailer = async (movie_id: number) => {
     console.error("API 호출 중 오류 발생:", error);
   }
 };
+
 const getNowPlayingMovie = async (page = 1, language = "ko-KR") => {
   try {
     const response = await axiosInstance.get(`/movie/now_playing`, {
@@ -19,6 +20,7 @@ const getNowPlayingMovie = async (page = 1, language = "ko-KR") => {
     throw error;
   }
 };
+
 const getUpComingMovie = async (page = 1, language = "ko-KR") => {
   try {
     const response = await axiosInstance.get(`/movie/upcoming`, {
@@ -30,6 +32,19 @@ const getUpComingMovie = async (page = 1, language = "ko-KR") => {
     throw error;
   }
 };
+
+const getTrendMovie = async (language = "ko-KR") => {
+  try {
+    const response = await axiosInstance.get(`/movie/popular`, {
+      params: { language },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("API 요청 중 오류 발생:");
+    throw error;
+  }
+};
+
 const getCredits = async (movie_id: number, language = "ko-KR") => {
   try {
     const response = await axiosInstance.get(`/movie/${movie_id}/credits`, {
@@ -40,6 +55,7 @@ const getCredits = async (movie_id: number, language = "ko-KR") => {
     console.error("API 호출 중 오류 발생:", error);
   }
 };
+
 const getGenres = async (language = "ko-KR") => {
   try {
     const response = await axiosInstance.get(`/genre/movie/list`, {
@@ -50,6 +66,7 @@ const getGenres = async (language = "ko-KR") => {
     console.error("API 호출 중 오류 발생:", error);
   }
 };
+
 const getProviders = async (movie_id: number, language = "ko-KR") => {
   try {
     const response = await axiosInstance.get(
@@ -63,6 +80,7 @@ const getProviders = async (movie_id: number, language = "ko-KR") => {
     console.error("API 호출 중 오류 발생:", error);
   }
 };
+
 const getMovie = async (movie_id: number) => {
   try {
     const response = await axiosInstance.get(`/movie/${movie_id}`, {
@@ -80,6 +98,7 @@ export const movieAPI = {
   getMovieTrailer,
   getNowPlayingMovie,
   getUpComingMovie,
+  getTrendMovie,
   getCredits,
   getGenres,
   getProviders,

--- a/src/api/tv.ts
+++ b/src/api/tv.ts
@@ -11,6 +11,7 @@ const getOnTheAirTvSeriese = async (page = 1, language = "ko-KR") => {
     throw error;
   }
 };
+
 const getSeries = async (series_id: number) => {
   try {
     const response = await axiosInstance.get(`/tv/${series_id}`, {
@@ -24,6 +25,7 @@ const getSeries = async (series_id: number) => {
     throw error;
   }
 };
+
 const getSeason = async (series_id: number, season_number: number) => {
   try {
     const response = await axiosInstance.get(
@@ -40,6 +42,7 @@ const getSeason = async (series_id: number, season_number: number) => {
     throw error;
   }
 };
+
 const getSeasonCredits = async (series_id: number, season_number: number) => {
   try {
     const response = await axiosInstance.get(
@@ -56,6 +59,7 @@ const getSeasonCredits = async (series_id: number, season_number: number) => {
     throw error;
   }
 };
+
 const getEpisode = async (
   series_id: number,
   season_number: number,
@@ -77,6 +81,17 @@ const getEpisode = async (
   }
 };
 
+const getTrendTv = async (language = "ko-KR") => {
+  try {
+    const response = await axiosInstance.get(`/trending/tv/week`, {
+      params: { language },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("API 요청 중 오류 발생:");
+    throw error;
+  }
+};
 
 export const tvAPI = {
   getOnTheAirTvSeriese,
@@ -84,4 +99,5 @@ export const tvAPI = {
   getSeason,
   getEpisode,
   getSeasonCredits,
+  getTrendTv,
 };

--- a/src/assets/icon/imagenone.svg
+++ b/src/assets/icon/imagenone.svg
@@ -1,0 +1,39 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1058_14162)">
+<rect width="100" height="100" rx="50" fill="#151515"/>
+<rect y="1" width="99" height="97.377" fill="#151515"/>
+<g filter="url(#filter0_f_1058_14162)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M43.1099 84.25L17.0107 39.0449V69.1816L43.1099 84.25Z" fill="#4CC9F0"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M43.1104 84.2529L17.0112 39.0479V69.1846L43.1104 84.2529Z" fill="#4CC9F0"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M34.3614 54.5991L76.972 29.9979L49.2307 13.9814L20.4907 30.5745L34.3614 54.5991Z" fill="#FAFAFA"/>
+<g filter="url(#filter1_i_1058_14162)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M34.3618 54.6005L34.3969 54.6613L77.043 30.0395L76.9728 29.999L34.3618 54.6005ZM52.1397 85.3927L37.8774 60.6896L80.8797 35.8622V68.7997L52.1397 85.3927Z" fill="#FAFAFA"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.475 31.3658L20.6228 30.7031L34.4053 54.5753L77.618 29.6265L81.0047 35.4924L37.7921 60.4412L52.1984 85.3938L77.9016 85.3937V98.3774H45.4426V96.5178L39.7315 94.7384L43.0612 84.0517L17.1218 39.1233L1.90785 36.1855L2.12085 35.0824H1.62256L1.62256 9.11523L19.475 9.11524V18.4954L35.0696 9.49185L40.4918 18.8834L19.475 31.0174V31.3658Z" fill="#151515"/>
+<rect width="100" height="100" rx="50" fill="#151515" fill-opacity="0.8"/>
+<path d="M47.3691 32.8594V47H44.8301L38.6191 38.0156H38.502V47H35.5723V32.8594H38.1504L44.3223 41.8438H44.459V32.8594H47.3691ZM62.7012 39.9297C62.7012 44.5391 59.8301 47.1953 56.0996 47.1953C52.3301 47.1953 49.4785 44.5195 49.4785 39.9297C49.4785 35.3203 52.3301 32.6641 56.0996 32.6641C59.8301 32.6641 62.7012 35.3203 62.7012 39.9297ZM59.7129 39.9297C59.7129 36.9023 58.2871 35.2617 56.0996 35.2617C53.9121 35.2617 52.4668 36.9023 52.4668 39.9297C52.4668 42.957 53.9121 44.5977 56.0996 44.5977C58.2871 44.5977 59.7129 42.957 59.7129 39.9297Z" fill="#4CC9F0"/>
+<path d="M21.5781 52.8594V67H18.6484V52.8594H21.5781ZM23.9609 52.8594H27.5938L31.5195 62.4492H31.6758L35.6016 52.8594H39.2344V67H36.3828V57.7422H36.2656L32.5742 66.9414H30.6211L26.9297 57.7031H26.8125V67H23.9609V52.8594ZM43.9805 67H40.8164L45.7188 52.8594H49.4883L54.3711 67H51.2266L50.1719 63.7383H45.0547L43.9805 67ZM45.7969 61.4531H49.4297L47.6523 56.043H47.5547L45.7969 61.4531ZM64.7031 57.4102C64.3125 56.082 63.2383 55.2617 61.6953 55.2617C59.5078 55.2617 58.0234 56.9414 58.0234 59.9102C58.0234 62.8984 59.4688 64.5977 61.7148 64.5977C63.7363 64.5977 64.9375 63.4551 64.9766 61.668H61.9102V59.4609H67.8086V61.2188C67.8086 64.9297 65.2695 67.1953 61.6953 67.1953C57.7305 67.1953 55.0352 64.4219 55.0352 59.9492C55.0352 55.3594 57.9062 52.6641 61.6367 52.6641C64.8203 52.6641 67.2812 54.6172 67.6719 57.4102H64.7031ZM69.957 67V52.8594H79.4492V55.2812H72.8867V58.7188H78.9609V61.1406H72.8867V64.5781H79.4688V67H69.957Z" fill="#FAFAFA"/>
+</g>
+<rect x="0.5" y="0.5" width="99" height="99" rx="49.5" stroke="#151515"/>
+<defs>
+<filter id="filter0_f_1058_14162" x="7.01074" y="29.0449" width="46.0991" height="65.2051" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="5" result="effect1_foregroundBlur_1058_14162"/>
+</filter>
+<filter id="filter1_i_1058_14162" x="34.3618" y="29.999" width="46.5181" height="59.3936" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_1058_14162"/>
+</filter>
+<clipPath id="clip0_1058_14162">
+<rect width="100" height="100" rx="50" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/icon/imagenone2.svg
+++ b/src/assets/icon/imagenone2.svg
@@ -1,0 +1,38 @@
+<svg width="242" height="146" viewBox="0 0 242 146" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1074_14215)">
+<rect width="241.1" height="145.75" fill="#151515"/>
+<rect x="71" y="24" width="99" height="97.377" fill="#151515"/>
+<g filter="url(#filter0_f_1074_14215)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M114.11 107.25L88.0107 62.0449V92.1816L114.11 107.25Z" fill="#4CC9F0"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M114.11 107.253L88.0112 62.0479V92.1846L114.11 107.253Z" fill="#4CC9F0"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M105.361 77.5991L147.972 52.9979L120.231 36.9814L91.4907 53.5745L105.361 77.5991Z" fill="#FAFAFA"/>
+<g filter="url(#filter1_i_1074_14215)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M105.362 77.6005L105.397 77.6613L148.043 53.0396L147.973 52.999L105.362 77.6005ZM123.14 108.393L108.877 83.6896L151.88 58.8622V91.7997L123.14 108.393Z" fill="#FAFAFA"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M90.475 54.3658L91.6228 53.7031L105.405 77.5753L148.618 52.6265L152.005 58.4924L108.792 83.4412L123.198 108.394L148.902 108.394V121.377H116.443V119.518L110.732 117.738L114.061 107.052L88.1218 62.1233L72.9079 59.1855L73.1209 58.0824H72.6226L72.6226 32.1152L90.475 32.1152V41.4954L106.07 32.4918L111.492 41.8834L90.475 54.0174V54.3658Z" fill="#151515"/>
+<rect width="241" height="146" fill="#151515" fill-opacity="0.8"/>
+<path d="M85.0215 65.8594V80H82.4824L76.2715 71.0156H76.1543V80H73.2246V65.8594H75.8027L81.9746 74.8438H82.1113V65.8594H85.0215ZM100.354 72.9297C100.354 77.5391 97.4824 80.1953 93.752 80.1953C89.9824 80.1953 87.1309 77.5195 87.1309 72.9297C87.1309 68.3203 89.9824 65.6641 93.752 65.6641C97.4824 65.6641 100.354 68.3203 100.354 72.9297ZM97.3652 72.9297C97.3652 69.9023 95.9395 68.2617 93.752 68.2617C91.5645 68.2617 90.1191 69.9023 90.1191 72.9297C90.1191 75.957 91.5645 77.5977 93.752 77.5977C95.9395 77.5977 97.3652 75.957 97.3652 72.9297Z" fill="#4CC9F0"/>
+<path d="M110.002 65.8594V80H107.072V65.8594H110.002ZM112.385 65.8594H116.018L119.943 75.4492H120.1L124.025 65.8594H127.658V80H124.807V70.7422H124.689L120.998 79.9414H119.045L115.354 70.7031H115.236V80H112.385V65.8594ZM132.404 80H129.24L134.143 65.8594H137.912L142.795 80H139.65L138.596 76.7383H133.479L132.404 80ZM134.221 74.4531H137.854L136.076 69.043H135.979L134.221 74.4531ZM153.127 70.4102C152.736 69.082 151.662 68.2617 150.119 68.2617C147.932 68.2617 146.447 69.9414 146.447 72.9102C146.447 75.8984 147.893 77.5977 150.139 77.5977C152.16 77.5977 153.361 76.4551 153.4 74.668H150.334V72.4609H156.232V74.2188C156.232 77.9297 153.693 80.1953 150.119 80.1953C146.154 80.1953 143.459 77.4219 143.459 72.9492C143.459 68.3594 146.33 65.6641 150.061 65.6641C153.244 65.6641 155.705 67.6172 156.096 70.4102H153.127ZM158.381 80V65.8594H167.873V68.2812H161.311V71.7188H167.385V74.1406H161.311V77.5781H167.893V80H158.381Z" fill="#FAFAFA"/>
+</g>
+<defs>
+<filter id="filter0_f_1074_14215" x="78.0107" y="52.0449" width="46.0991" height="65.2051" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="5" result="effect1_foregroundBlur_1074_14215"/>
+</filter>
+<filter id="filter1_i_1074_14215" x="105.362" y="52.999" width="46.5181" height="59.3936" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_1074_14215"/>
+</filter>
+<clipPath id="clip0_1074_14215">
+<rect width="241.1" height="145.75" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/common/Episodes.tsx
+++ b/src/components/common/Episodes.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { IMAGE_BASE_URL } from "../../api/axios";
+import imagenone2 from "../../assets/icon/imagenone2.svg";
 
 export default function Episodes({
   seriesId,
@@ -26,10 +27,13 @@ export default function Episodes({
           >
             {/* 스틸컷 */}
             <div
-              className="tablet:w-[323px] mobile:w-full bg-white bg-cover bg-center"
+              className="tablet:w-[323px] mobile:w-full bg-white bg-cover bg-center
+              border-[1px] border-main"
               style={{
                 aspectRatio: "1661 / 1000",
-                backgroundImage: `url(${IMAGE_BASE_URL}original${epi.still_path})`,
+                backgroundImage: epi.still_path
+                  ? `url(${IMAGE_BASE_URL}original${epi.still_path})`
+                  : `url(${imagenone2})`,
               }}
             ></div>
 

--- a/src/components/common/MainThumbnail.tsx
+++ b/src/components/common/MainThumbnail.tsx
@@ -1,32 +1,102 @@
+import { useEffect, useState } from "react";
 import placeholderImg03 from "../../assets/placeholderImg03.svg";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
+import { tvAPI } from "../../api/tv";
+import { movieAPI } from "../../api/movie";
+import { IMAGE_BASE_URL } from "../../api/axios";
+import { Swiper, SwiperSlide } from "swiper/react"; // Swiper import
+import "swiper/swiper-bundle.css"; // Swiper 스타일 import
 
 export default function MainThumbnail() {
+  const [contents, setContents] = useState<popularContentType[]>();
+  const location = useLocation();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const popularTv = await tvAPI.getTrendTv();
+        const popularMovie = await movieAPI.getTrendMovie();
+
+        const shuffleArray = (array: popularContentType[]) => {
+          return array
+            .map((item) => ({ item, sortKey: Math.random() }))
+            .sort((a, b) => a.sortKey - b.sortKey)
+            .map(({ item }) => item);
+        };
+
+        const popularSum = shuffleArray([
+          ...popularTv.results,
+          ...popularMovie.results,
+        ]);
+
+        if (location.pathname === "/") {
+          setContents(popularTv.results.slice(0, 5));
+          console.log(popularTv.results);
+        } else if (location.pathname === "/series") {
+          setContents(popularMovie.results.slice(0, 5));
+          console.log(popularMovie.results);
+        } else if (location.pathname === "/movies") {
+          setContents(popularSum.slice(0, 5));
+          console.log(popularSum);
+        }
+      } catch (error) {
+        console.error(Error);
+      }
+    };
+    fetchData();
+  }, [location.pathname]);
+
   return (
     /* 임시로 시리즈 상세 페이지에 연결함 */
     <>
       {/* tablet 이상 */}
-      <Link
-        to={"/detailseries/96102"} // 임시로 슬기로운의사생활 id 적용
-        className="relative hidden tablet:flex flex-col justify-center 
-        items-center w-full h-[720px] bg-cover bg-center py-[80px] px-[100px]"
-        style={{ backgroundImage: `url(${placeholderImg03})` }}
+      <Swiper
+        spaceBetween={10} // 슬라이드 사이 간격
+        slidesPerView={1} // 한 번에 보여지는 슬라이드 수
+        loop={true} // 무한 반복
+        className="w-full"
       >
-        {/* 그라데이션 오버레이 */}
-        <div
-          className="absolute inset-0 bg-gradient-to-t from-black 
-        via-black/50 to-transparent opacity-80"
-        ></div>
+        {contents?.map((content) => (
+          <SwiperSlide key={content.id}>
+            <Link
+              key={content.id}
+              to={
+                content.title
+                  ? `/detailmovie/${content.id}`
+                  : `/detailseries/${content.id}`
+              } // 임시로 슬기로운의사생활 id 적용
+              className="relative hidden tablet:flex flex-col justify-center 
+              items-center w-full h-[720px] bg-cover bg-center py-[80px] px-[100px]"
+              style={{
+                backgroundImage: `url(${IMAGE_BASE_URL}original${content.backdrop_path})`,
+              }}
+            >
+              {/* 그라데이션 오버레이 */}
+              <div
+                className="absolute inset-0 bg-gradient-to-t from-black 
+              via-black/50 to-transparent opacity-100"
+              ></div>
 
-        {/* 텍스트 */}
-        <div
-          className="w-full h-full flex flex-col justify-end items-start 
-        gap-[10px] relative z-10 text-center text-white"
-        >
-          <div className="font-bold text-[60px] leading-none">영화 제목</div>
-          <div className="text-[24px] leading-none">요약 내용</div>
-        </div>
-      </Link>
+              {/* 텍스트 */}
+              <div
+                className="w-full h-full flex flex-col justify-end items-start 
+                gap-[10px] relative z-10 text-center text-white"
+              >
+                <div className="font-bold text-[60px] leading-none">
+                  {content.title ? content.title : content.name}
+                </div>
+                <div
+                  className="text-[24px] text-left leading-[40px] 
+                line-clamp-2 overflow-hidden whitespace-normal 
+                hover:line-clamp-none hover:overflow-visible "
+                >
+                  {content.overview}
+                </div>
+              </div>
+            </Link>
+          </SwiperSlide>
+        ))}
+      </Swiper>
 
       {/* mobile 전용 */}
       <Link

--- a/src/components/common/PersonList.tsx
+++ b/src/components/common/PersonList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { tvAPI } from "../../api/tv";
 import { IMAGE_BASE_URL } from "../../api/axios";
 import { movieAPI } from "../../api/movie";
+import imagenone from "../../assets/icon/imagenone.svg";
 
 export default function PersonList({
   seriesId,
@@ -138,11 +139,12 @@ export default function PersonList({
               {/* 프로필 이미지 */}
               <div
                 className="bg-white tablet:w-[100px] mobile:w-[60px] 
-                aspect-square bg-cover bg-center rounded-full z-10"
+                aspect-square bg-cover bg-center rounded-full z-10
+                border-[1px] border-main"
                 style={{
                   backgroundImage: person.profile_path
                     ? `url(${IMAGE_BASE_URL}original${person.profile_path})`
-                    : `url(/default-profile.png)`, // 기본 이미지 처리
+                    : `url(${imagenone})`, // 기본 이미지 처리
                 }}
               ></div>
 

--- a/src/pages/DetailMovie.tsx
+++ b/src/pages/DetailMovie.tsx
@@ -4,9 +4,13 @@ import Arguments from "../components/common/Arguments";
 import DetailIntroBox from "../components/common/DetailIntroBox";
 import PersonList from "../components/common/PersonList";
 import Reviews from "../components/common/Reviews";
+import { useLocation } from "react-router-dom";
 
 export default function DetailMovie() {
   const [activeTab, setActiveTab] = useState<number>(0);
+  const location = useLocation();
+  const contentId = location.pathname.split("/")[2];
+
   // 더미데이터 예시
   const dummyreviews = [
     {
@@ -96,14 +100,14 @@ export default function DetailMovie() {
 
   return (
     <>
-      <DetailIntroBox />
+      <DetailIntroBox contentId={Number(contentId)} type="movie" />
       <section className="flex flex-col jutify-evenly w-full tablet:gap-[50px] mobile:gap-[30px] desktop:px-[128px] tablet:px-[40px] mobile:px-[10px] tablet:mt-[50px] mobile:mt-[30px]">
         {/* 영상 스와이퍼(아직 컴포넌트 완성 X) */}
 
         {/* 출연진 */}
-        <PersonList label="출연진" />
+        <PersonList seriesId={Number(contentId)} label="출연진" type="movie" />
         {/* 제작진 */}
-        <PersonList label="제작진" />
+        <PersonList seriesId={Number(contentId)} label="제작진" type="movie" />
         {/* 리뷰토론 */}
         <section className="flex flex-col">
           {/* 텝 */}
@@ -126,8 +130,8 @@ export default function DetailMovie() {
           {activeTab === 0 && <Reviews />}
           {activeTab === 1 && <Arguments />}
         </section>
-        <ArgorithmIP label="추천" />
-        <ArgorithmIP label="유사한 작품" />
+        {/* <ArgorithmIP label="추천" />
+        <ArgorithmIP label="유사한 작품" /> */}
       </section>
     </>
   );

--- a/src/pages/DetailSeason.tsx
+++ b/src/pages/DetailSeason.tsx
@@ -128,7 +128,7 @@ export default function DetailSeason() {
 
   return (
     <>
-      <DetailIntroBox data={seriesData} season={seasonData} />
+      <DetailIntroBox contentId={Number(locationInfo[1])} type="tvSeries" />
       <section
         className="border border-white flex flex-col jutify-evenly w-full 
       tablet:gap-[50px] mobile:gap-[30px] 
@@ -142,14 +142,14 @@ export default function DetailSeason() {
           seriesId={Number(locationInfo[1])}
           seasonNum={Number(locationInfo[2])}
           label="출연진"
-          type="cast"
+          type="tv"
         />
         {/* 제작진 */}
         <PersonList
           seriesId={Number(locationInfo[1])}
           seasonNum={Number(locationInfo[2])}
           label="제작진"
-          type="crew"
+          type="tv"
         />
         {/* 에피소드 리스트 */}
         <Episodes
@@ -180,8 +180,8 @@ export default function DetailSeason() {
           {activeTab === 0 && <Reviews />}
           {activeTab === 1 && <Arguments />}
         </section>
-        <ArgorithmIP label="추천" />
-        <ArgorithmIP label="유사한 작품" />
+        {/* <ArgorithmIP label="추천" />
+        <ArgorithmIP label="유사한 작품" /> */}
       </section>
     </>
   );

--- a/src/pages/DetailSeason.tsx
+++ b/src/pages/DetailSeason.tsx
@@ -128,7 +128,7 @@ export default function DetailSeason() {
 
   return (
     <>
-      <DetailIntroBox contentId={Number(locationInfo[1])} type="tvSeries" />
+      <DetailIntroBox contentId={Number(locationInfo[1])} type="tvSeason" />
       <section
         className="border border-white flex flex-col jutify-evenly w-full 
       tablet:gap-[50px] mobile:gap-[30px] 

--- a/src/pages/DetailSeries.tsx
+++ b/src/pages/DetailSeries.tsx
@@ -26,7 +26,7 @@ export default function DetailSeries() {
 
   return (
     <div>
-      <DetailIntroBox data={contentData} />
+      <DetailIntroBox contentId={Number(locationInfo[1])} type="tvSeries" />
       {contentData?.seasons.map((season) => (
         <SeasonBox
           key={season.id}

--- a/src/type/type.d.ts
+++ b/src/type/type.d.ts
@@ -325,3 +325,24 @@ interface ReviewType {
   date: string;
   isMine?: boolean;
 }
+
+interface popularContentType {
+  adult: boolean;
+  backdrop_path: string;
+  genre_ids: number[];
+  id: number;
+  original_country?: string[];
+  original_language: string;
+  original_title?: string;
+  original_name?: string;
+  overview: string;
+  popularity: number;
+  poster_path: string;
+  first_air_date?: string;
+  release_date?: string;
+  name?: string;
+  title?: string;
+  video?: boolean;
+  vote_average: number;
+  vote_count: number;
+}

--- a/src/type/type.d.ts
+++ b/src/type/type.d.ts
@@ -132,6 +132,7 @@ interface CreditInfoType {
   popularity: number;
   profile_path: string;
 }
+
 // tv 시리즈
 interface TvSeriesType {
   adult: boolean;
@@ -172,6 +173,8 @@ interface TvSeriesType {
   tagline: string;
   vote_average: number;
 }
+
+// Tv 시즌 타입
 interface TvSeasonsType {
   air_date: string;
   episode_count: number;
@@ -184,6 +187,84 @@ interface TvSeasonsType {
   episodes: EpisodeType[];
 }
 
+// 에피소드 타입
+interface EpisodeType {
+  air_date: string;
+  episode_number: number;
+  episode_type: string;
+  id: number;
+  name: string;
+  overview: string;
+  runtime: number;
+  season_number: number;
+  show_id: number;
+  still_path: string;
+  vote_average: number;
+  vote_count: number;
+  crew: {
+    job: string;
+    department: string;
+    credit_id: string;
+    adult: boolean;
+    gender: number;
+    id: number;
+    known_for_department: string;
+    name: string;
+    original_name: string;
+    popularity: number;
+    profile_path: string;
+  }[];
+  guest_stars: {
+    character: string;
+    credit_id: string;
+    order: number;
+    adult: boolean;
+    gender: number;
+    id: number;
+    known_for_department: string;
+    name: string;
+    original_name: string;
+    popularity: number;
+    profile_path: string;
+  }[];
+}
+
+// Movie 타입
+interface MovieType {
+  adult: boolean;
+  backdrop_path: string;
+  belongs_to_collection: null;
+  budget: number;
+  genres: { id: number; name: string }[];
+  homepage: string;
+  id: number;
+  imdb_id: string;
+  origin_country: string[];
+  original_language: string;
+  original_title: string;
+  overview: string;
+  popularity: number;
+  poster_path: string;
+  production_companies: {
+    id: number;
+    logo_path: string;
+    name: string;
+    origin_country: string;
+  }[];
+  production_countries: { iso_3166_1: string; name: string }[];
+  release_date: string;
+  revenue: number;
+  runtime: number;
+  spoken_languages: { english_name: string; iso_639_1: string; name: string }[];
+  status: string;
+  tagline: string;
+  title: string;
+  video: boolean;
+  vote_average: number;
+  vote_count: number;
+}
+
+// 인물종합정보 타입
 interface PersonDataType {
   adult: boolean;
   cast_id?: number;
@@ -228,47 +309,6 @@ interface movieCrewPersonType {
   original_name: string;
   populartiy: number;
   profile_path: string;
-}
-
-interface EpisodeType {
-  air_date: string;
-  episode_number: number;
-  episode_type: string;
-  id: number;
-  name: string;
-  overview: string;
-  runtime: number;
-  season_number: number;
-  show_id: number;
-  still_path: string;
-  vote_average: number;
-  vote_count: number;
-  crew: {
-    job: string;
-    department: string;
-    credit_id: string;
-    adult: boolean;
-    gender: number;
-    id: number;
-    known_for_department: string;
-    name: string;
-    original_name: string;
-    popularity: number;
-    profile_path: string;
-  }[];
-  guest_stars: {
-    character: string;
-    credit_id: string;
-    order: number;
-    adult: boolean;
-    gender: number;
-    id: number;
-    known_for_department: string;
-    name: string;
-    original_name: string;
-    popularity: number;
-    profile_path: string;
-  }[];
 }
 
 // 장르 기본 타입

--- a/src/type/type.d.ts
+++ b/src/type/type.d.ts
@@ -186,16 +186,48 @@ interface TvSeasonsType {
 
 interface PersonDataType {
   adult: boolean;
+  cast_id?: number;
+  character?: string;
+  credit_id: string;
+  department?: string;
   gender: number;
-  id: number;
+  id: string;
+  known_for_department: string;
+  name: string;
+  order?: number;
+  original_name: string;
+  populartiy: number;
+  profile_path: string;
+}
+
+// 영화 출연진 타입
+interface movieCastPersonType {
+  adult: boolean;
+  cast_id: number;
+  character: string;
+  credit_id: string;
+  gender: number;
+  id: string;
+  known_for_department: string;
+  name: string;
+  order: number;
+  original_name: string;
+  populartiy: number;
+  profile_path: string;
+}
+
+// 영화 제작진 타입
+interface movieCrewPersonType {
+  adult: boolean;
+  credit_id: string;
+  department: string;
+  gender: number;
+  id: string;
   known_for_department: string;
   name: string;
   original_name: string;
-  popularity: number;
+  populartiy: number;
   profile_path: string;
-  character: string;
-  credit_id: string;
-  order: number;
 }
 
 interface EpisodeType {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- 메인썸네일에 스와이퍼 적용 및 trend 컨텐츠 데이터 연결
- 상세페이지 데이터 연결 (시리즈/시즌/에피소드 및 영화별로 각각)
- 출연진 데이터 연결 및 이미지 없을 경우 기본 이미지 적용
- 에피소드 데이터 연결 및 이미지 없을 경우 기본 이미지 적용

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/b93d2de8-ec7c-42ca-905f-bc3e62939fcd)
![image](https://github.com/user-attachments/assets/0d840a15-31db-4dc4-a51a-2dd5c1e4fbb1)
![image](https://github.com/user-attachments/assets/af023486-7b63-491d-9027-d3d527e5d884)
![image](https://github.com/user-attachments/assets/93720d0f-7181-4c27-89cd-c90f90c8bb71)
