### PR TITLE
Fix 콘텐츠리스트 스와이퍼적용 #84

### DIFF
--- a/src/components/common/ArgorithmIP.tsx
+++ b/src/components/common/ArgorithmIP.tsx
@@ -64,19 +64,16 @@ export default function ArgorithmIP({
 
       {/* 컨텐츠 내용 */}
       <Swiper
-        // spaceBetween={10} // 슬라이드 사이 간격
-        // slidesPerView={5} // 한 번에 보여지는 슬라이드 수
         breakpoints={{
-          320: { slidesPerView: 2, spaceBetween: 5 },
-          480: { slidesPerView: 3, spaceBetween: 10 },
-          768: { slidesPerView: 4, spaceBetween: 15 },
-          1024: { slidesPerView: 5, spaceBetween: 20 },
-          1280: { slidesPerView: 6, spaceBetween: 20 },
+          320: { slidesPerView: 2 },
+          600: { slidesPerView: 3 },
+          880: { slidesPerView: 4 },
+          1090: { slidesPerView: 5 },
+          1300: { slidesPerView: 6 },
         }}
         loop={false} // 무한 반복
         className="w-full"
       >
-        {/* <div className="flex justify-start gap-[30px] tablet:h-full mobile:h-[132.5px]"> */}
         {contents?.length === 0 ? (
           <div className="text-[16px] text-white02 font-light">
             {translation.noResult}
@@ -106,8 +103,8 @@ export default function ArgorithmIP({
 
                 {/* 제목(연도) */}
                 <div
-                  className="font-bold text-[16px] text-white02
-                  line-clamp-2 overflow-hidden whitespace-normal 
+                  className="tablet:w-[200px] mobile:w-[100px] font-bold text-[16px] text-white02
+                  line-clamp-1 overflow-hidden whitespace-normal 
                   hover:line-clamp-none hover:overflow-visible"
                 >
                   {item.title ? item.title : item.name}(
@@ -120,8 +117,6 @@ export default function ArgorithmIP({
             </SwiperSlide>
           ))
         )}
-
-        {/* </div> */}
       </Swiper>
     </section>
   );

--- a/src/components/common/Contents.tsx
+++ b/src/components/common/Contents.tsx
@@ -4,6 +4,9 @@ import { useEffect, useRef, useState } from "react";
 import { useLanguageStore } from "../../store/useLanguageStore";
 import { menuTranslations } from "../../translations/menu";
 import defaultImage from "../../assets/icon/imagenone2.svg";
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/swiper-bundle.css";
+import { Navigation, Pagination } from "swiper/modules";
 
 interface ChildProps {
   to: string;
@@ -96,16 +99,20 @@ export default function Contents({
             )}
           </div>
 
-          <div
-            className="flex gap-[20px] overflow-x-auto overflow-y-hidden"
-            ref={dataRef}
+          <Swiper
+            modules={[Navigation, Pagination]}
+            spaceBetween={10}
+            slidesPerView={3}
+            className="w-full hidden tablet:flex"
+            breakpoints={{
+              900: { slidesPerView: 4 },
+              1100: { slidesPerView: 5 },
+              1300: { slidesPerView: 6 },
+            }}
           >
             {trendingData?.map((_, index) => {
               return (
-                <div
-                  key={index}
-                  className="flex flex-col justify-start items-center w-[200px] shrink-0 gap-[10px]"
-                >
+                <SwiperSlide key={index}>
                   <img
                     className={`w-[200px] h-[265px] rounded-[8px] cursor-pointer`}
                     src={trendingData[index].poster_path || defaultImage}
@@ -116,17 +123,17 @@ export default function Contents({
                       navigate(path[index]);
                     }}
                   />
-                  <div className="relative w-full px-[10px]">
+                  <div className="relative w-[200px] px-[10px]">
                     <p className="text-left overflow-hidden whitespace-nowrap text-ellipsis hover:whitespace-normal hover:overflow-visible">
                       {trendingData[index].name
                         ? trendingData[index].name
                         : trendingData[index].title}
                     </p>
                   </div>
-                </div>
+                </SwiperSlide>
               );
             })}
-          </div>
+          </Swiper>
         </div>
 
         {/* mobile 전용 */}
@@ -142,15 +149,17 @@ export default function Contents({
             )}
           </div>
 
-          <div className="flex overflow-y-auto gap-[10px]">
+          <Swiper
+            modules={[Navigation, Pagination]}
+            spaceBetween={10}
+            slidesPerView={3}
+            className="w-full hidden tablet:flex"
+          >
             {trendingData.map((_, index) => {
               return (
-                <div
-                  key={index}
-                  className="flex flex-col justify-start items-center w-[200px] shrink-0 gap-[10px]"
-                >
+                <SwiperSlide key={index}>
                   <img
-                    className={`w-[200px] h-[265px] rounded-[8px] cursor-pointer`}
+                    className={`w-[100px] h-[132.5px] rounded-[8px] cursor-pointer`}
                     src={trendingData[index].poster_path || defaultImage}
                     onError={(e) => {
                       (e.currentTarget as HTMLImageElement).src = defaultImage;
@@ -160,17 +169,17 @@ export default function Contents({
                       navigate(path[index]);
                     }}
                   />
-                  <div className="relative w-full">
+                  <div className="relative w-[100px] px-[2px]">
                     <p className="text-center overflow-hidden whitespace-nowrap text-ellipsis">
                       {trendingData[index].name
                         ? trendingData[index].name
                         : trendingData[index].title}
                     </p>
                   </div>
-                </div>
+                </SwiperSlide>
               );
             })}
-          </div>
+          </Swiper>
         </div>
       </>
     );

--- a/src/components/common/MediaList.tsx
+++ b/src/components/common/MediaList.tsx
@@ -46,7 +46,6 @@ export default function MediaList({
             className="w-full hidden tablet:flex"
             breakpoints={{
               900: { slidesPerView: 4 },
-              // 1100: { slidesPerView: 4 },
               1100: { slidesPerView: 5 },
               1300: { slidesPerView: 6 },
             }}

--- a/src/components/common/MediaList.tsx
+++ b/src/components/common/MediaList.tsx
@@ -1,11 +1,11 @@
-import { Link, useNavigate } from "react-router-dom";
-
-import { mediaTypeToPathName } from "../../constants/path";
+import { Link } from "react-router-dom";
 import { IMAGE_BASE_URL } from "../../api/axios";
 import { useLanguageStore } from "../../store/useLanguageStore";
 import { menuTranslations } from "../../translations/menu";
 import defaultImage from "../../assets/icon/imagenone2.svg";
-import { useEffect, useRef, useState } from "react";
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/swiper-bundle.css";
+import { Navigation, Pagination } from "swiper/modules";
 
 interface ChildProps {
   to: string;
@@ -20,16 +20,6 @@ export default function MediaList({
   data,
   children,
 }: ChildProps) {
-  const path =
-    data?.map((item) =>
-      item.media_type && mediaTypeToPathName[item.media_type as "movie" | "tv"]
-        ? `/${mediaTypeToPathName[item.media_type as "movie" | "tv"]}/${
-            item.id
-          }`
-        : ""
-    ) ?? [];
-
-  const navigate = useNavigate();
   const { language } = useLanguageStore();
   const translation = menuTranslations[language];
 
@@ -49,40 +39,53 @@ export default function MediaList({
             )}
           </div>
 
-          <div
-            className="flex gap-[20px] overflow-x-auto overflow-y-hidden"
-            ref={dataRef}
+          <Swiper
+            modules={[Navigation, Pagination]}
+            spaceBetween={10}
+            slidesPerView={3}
+            className="w-full hidden tablet:flex"
+            breakpoints={{
+              900: { slidesPerView: 4 },
+              // 1100: { slidesPerView: 4 },
+              1100: { slidesPerView: 5 },
+              1300: { slidesPerView: 6 },
+            }}
           >
             {data.map((item, index) => {
               return (
-                <div
-                  key={index}
-                  className="flex flex-col justify-start items-center w-[200px] shrink-0 gap-[10px]"
-                >
-                  <img
-                    className="w-[200px] h-[265px] rounded-[8px] cursor-pointer"
-                    src={
-                      item.poster_path
-                        ? `${IMAGE_BASE_URL}original${item.poster_path}`
-                        : defaultImage
-                    }
-                    alt={item.name}
-                    onError={(e) => {
-                      (e.currentTarget as HTMLImageElement).src = defaultImage;
+                <SwiperSlide key={index}>
+                  <div
+                    key={index}
+                    className="w-[200px] h-[265px] rounded-[8px] cursor-pointer
+                    bg-cover bg-center"
+                    style={{
+                      backgroundImage: `url(${
+                        item.poster_path
+                          ? `${IMAGE_BASE_URL}original${item.poster_path}`
+                          : item.backdrop_path
+                            ? `${IMAGE_BASE_URL}original${item.backdrop_path}`
+                            : defaultImage
+                      })`,
                     }}
-                    onClick={() => {
-                      navigate(path[index]);
-                    }}
-                  />
-                  <div className="relative w-full px-[10px]">
+                  >
+                    <Link
+                      to={
+                        item.title
+                          ? `/detailmovie/${item.id}`
+                          : `/detailseries/${item.id}`
+                      }
+                      className="block w-full h-full"
+                    ></Link>
+                  </div>
+                  <div className="relative w-[200px] px-[10px]">
                     <p className="text-left overflow-hidden whitespace-nowrap text-ellipsis hover:whitespace-normal hover:overflow-visible">
                       {item.name ? item.name : item.title}
                     </p>
                   </div>
-                </div>
+                </SwiperSlide>
               );
             })}
-          </div>
+          </Swiper>
         </div>
 
         {/* mobile 전용 */}
@@ -98,21 +101,47 @@ export default function MediaList({
             )}
           </div>
 
-          <div className="flex overflow-y-auto gap-[10px]">
+          <Swiper
+            modules={[Navigation, Pagination]}
+            spaceBetween={10}
+            slidesPerView={3}
+            className="w-full hidden tablet:flex"
+          >
             {data.map((item, index) => {
               return (
-                <img
-                  className="w-[200px] h-[265px] border-[1px] rounded-[8px] border-gray01"
-                  src={`${IMAGE_BASE_URL}original${item.poster_path}`}
-                  alt={item.name}
-                  key={index}
-                  onClick={() => {
-                    navigate(path[index]);
-                  }}
-                />
+                <SwiperSlide key={index}>
+                  <div
+                    key={index}
+                    className="w-[100px] h-[132.5px] rounded-[8px] cursor-pointer
+                    bg-cover bg-center"
+                    style={{
+                      backgroundImage: `url(${
+                        item.poster_path
+                          ? `${IMAGE_BASE_URL}original${item.poster_path}`
+                          : item.backdrop_path
+                            ? `${IMAGE_BASE_URL}original${item.backdrop_path}`
+                            : defaultImage
+                      })`,
+                    }}
+                  >
+                    <Link
+                      to={
+                        item.title
+                          ? `/detailmovie/${item.id}`
+                          : `/detailseries/${item.id}`
+                      }
+                      className="block w-full h-full"
+                    ></Link>
+                  </div>
+                  <div className="relative w-[100px] px-[2px]">
+                    <p className="text-left text-[14px] overflow-hidden whitespace-nowrap text-ellipsis">
+                      {item.name ? item.name : item.title}
+                    </p>
+                  </div>
+                </SwiperSlide>
               );
             })}
-          </div>
+          </Swiper>
         </div>
       </>
     );

--- a/src/components/mypage/ScrapEpisode.tsx
+++ b/src/components/mypage/ScrapEpisode.tsx
@@ -10,7 +10,7 @@ export default function ScrapEpisode({
       {episodeClips?.map((clip) => (
         <div key={clip.ip_id}>
           <EpisodeContent
-            ip_id={`detailepisode/${clip.ip_id}`}
+            ip_id={`${clip.ip_id}`}
             ip_name={clip.ip_name}
             poster_path={clip.poster_path}
             summary={clip.summary}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- 메인페이지 및 시리즈/영화 탭 내 컨텐츠 리스트에 스와이퍼 적용
- 스크랩 에피소드를 클릭 시 "detailepisode/"가 2번 적용되어 오류가 나는 문제 해결
- 디바이스별 스와이퍼 이미지 수 조정

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/ab9264cf-20c6-45d1-83ff-4ae243306c81)
![image](https://github.com/user-attachments/assets/2f6a353b-7ab0-46df-9df5-688a9a44b6fe)
![image](https://github.com/user-attachments/assets/4d68740d-6a0a-4e02-a59e-be503bcd1741)
